### PR TITLE
feat: reproduceable leadership lost issue

### DIFF
--- a/producer/main.go
+++ b/producer/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/nats-io/stan"
 )
@@ -26,18 +25,10 @@ func main() {
 	}
 	defer sc.Close()
 
-	sub, err := sc.Subscribe("foo", func(m *stan.Msg) {
-		if err := m.Ack(); err != nil {
+	for {
+		if err := sc.Publish("foo", []byte("msg")); err != nil {
 			log.Println(err)
 		}
-		// fake processing time
-		time.Sleep(time.Millisecond * 10)
 		fmt.Print(".")
-	}, stan.MaxInflight(10), stan.SetManualAckMode())
-	if err != nil {
-		log.Fatalln(err)
 	}
-	defer sub.Unsubscribe()
-
-	time.Sleep(1000 * time.Hour)
 }


### PR DESCRIPTION
to reproduce:

- start the cluster
- `go run producer/main.go prod1 nats://localhost:4221 nats://localhost:4222 nats://localhost:4223`
- `go run producer/main.go prod2 nats://localhost:4221 nats://localhost:4222 nats://localhost:4223`
- `go run main.go cli1 nats://localhost:4221 nats://localhost:4222 nats://localhost:4223`
- `go run main.go cli2 nats://localhost:4221 nats://localhost:4222 nats://localhost:4223`

it should all fail after ~3m with on client:

```
2019/06/11 12:50:20 Connection lost, reason: stan: connection lost due to PING failure, will retry
```

on producers:

```
2019/06/11 12:50:19 Connection lost, reason: stan: connection lost due to PING failure, will retry
2019/06/11 12:50:19 stan: connection closed
```

on nats:

```
node2_1  | [1] 2019/06/11 15:50:01.795571 [INF] STREAM: Deleting raft logs from 209156 to 253011
node2_1  | [1] 2019/06/11 15:50:01.828021 [INF] STREAM: Deletion took 32.4438ms
node3_1  | [1] 2019/06/11 15:50:17.524157 [INF] STREAM: server lost leadership, performing leader stepdown actions
node3_1  | [1] 2019/06/11 15:50:17.524279 [INF] STREAM: finished leader stepdown actions
node3_1  | [1] 2019/06/11 15:50:17.524605 [ERR] STREAM: [Client:prod1] Error processing message for subject "_STAN.pub.test-cluster.foo": leadership lost while committing log
node2_1  | [1] 2019/06/11 15:50:19.948538 [INF] STREAM: server became leader, performing leader promotion actions
node2_1  | [1] 2019/06/11 15:50:19.962345 [INF] STREAM: finished leader promotion actions
node3_1  | [1] 2019/06/11 15:50:40.547322 [INF] STREAM: Deleting raft logs from 188326 to 258565
node3_1  | [1] 2019/06/11 15:50:40.575468 [INF] STREAM: Deletion took 28.1328ms
```
